### PR TITLE
update electron version -> 1.2.5

### DIFF
--- a/resources/leiningen/new/descjop/Gruntfile.js
+++ b/resources/leiningen/new/descjop/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function(grunt) {
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         "download-electron": {
-            version: "0.37.5",
+            version: "1.2.5",
             outputDir: "./electron",
             // if you want to download electron into project directory
             // downloadDir: ".electron-download",

--- a/resources/leiningen/new/descjop/src__core.cljs
+++ b/resources/leiningen/new/descjop/src__core.cljs
@@ -5,9 +5,9 @@
 
 (def Electron (nodejs/require "electron"))
 
-(def BrowserWindow (nodejs/require "browser-window"))
+(def BrowserWindow (.-BrowserWindow Electron))
 
-(def crash-reporter (nodejs/require "crash-reporter"))
+(def crash-reporter (.-crashReporter Electron))
 
 (def Os (nodejs/require "os"))
 


### PR DESCRIPTION
I want to use the newest Electron.
So update electron version -> 1.2.5!

I'm a electron & cljs beginner... 
I'm very grad to correct a mistake if i make it 😄 

---

![image](https://cloud.githubusercontent.com/assets/3142849/16543665/49aa7df8-411c-11e6-881b-a5b6563670ec.png)
